### PR TITLE
Fix German names for U+2013 U+2014 U+2213 U+2214

### DIFF
--- a/loc/de/symbols/2000.txt
+++ b/loc/de/symbols/2000.txt
@@ -17,8 +17,8 @@
 2010: Bindestrich : Divis, Hyphen
 2011: Geschützter Bindestrich : Nicht-umbrechender Bindestrich, Non-breaking Hyphen
 2012: Figure dash
-2013: En dash
-2014: Em dash
+2013: Halbgeviertstrich
+2014: Geviertstrich
 2015: Horizontal bar
 2016: Double vertical line
 2017: Double low line

--- a/loc/de/symbols/2200.txt
+++ b/loc/de/symbols/2200.txt
@@ -17,8 +17,8 @@
 2210: N-ary coproduct
 2211: N-ary summation
 2212: Minuszeichen
-2213: Halbgeviertstrich
-2214: Geviertstrich
+2213: Minus-oder-Plus-Zeichen
+2214: Dot plus
 2215: Division slash
 2216: Set minus
 2217: Asterisk operator


### PR DESCRIPTION
Currently, searching for "Halbgeviertstrich" in the German version will incorrectly yield the minus-or-plus sign. This pull request fixes this and a similar problem for the "Geviertstrich".