### PR TITLE
Correct outdated/inaccurate language for U+26a7 and related trans symbols in English

### DIFF
--- a/loc/en/symbols/2600.txt
+++ b/loc/en/symbols/2600.txt
@@ -163,9 +163,9 @@
 26A2: Doubled Female Sign : lesbianism
 26A3: Doubled Male Sign : male homosexuality
 26A4: Interlocked Female and Male Sign : bisexuality
-26A5: Male and Female Sign : transgendered sexuality : hermaphrodite (in entomology)
-26A6: Male with Stroke Sign : transgendered sexuality : alchemical symbol for iron or crocus of iron
-26A7: Male with Stroke and Male and Female Sign : transgendered sexuality
+26A5: Male and Female Sign : transgender : hermaphrodite (in entomology)
+26A6: Male with Stroke Sign : transgender : alchemical symbol for iron or crocus of iron
+26A7: Male with Stroke and Male and Female Sign : transgender
 26A8: Vertical Male with Stroke Sign : alchemical symbol for iron
 26A9: Horizontal Male with Stroke Sign : alchemical symbol for iron
 26AA: Medium White Circle : asexuality, sexless, genderless : engaged, betrothed


### PR DESCRIPTION
The current subtitles for the character U+26a7 (⚧) and a couple neighboring symbols uses the phrase "transgendered sexuality", which I feel may be misleading or inaccurate.  There exist two issues with this phrasing:  First, transgender is a term that describes gender, not sexuality.  I don't believe this character is anywhere used in colloquial language in reference to any sort of sexuality, and I think that labeling it as such could be inaccurate, unless someone has a source to the contrary.  In addition, the term "transgendered", while still occasionally heard, is generally thought of as being dated, with many of the terms users using it out of ignorance or malice.  I believe that continuing to use this term might be seen as being dated or making a statement that was never intended to be made.  "Transgender" is a more neutral and accepted term with the same meaning.

It may also be worth noting that this is how [the official Unicode documentation](https://www.unicode.org/charts/PDF/U2600.pdf) refers to these signs.  

![transgender](https://user-images.githubusercontent.com/38897201/60757142-c811be80-9fd4-11e9-90c9-658b20c8b1de.png)

I'd also like to issue an apology if these subtitles are coming from a source elsewhere in the Unicode consortium that I missed, and/or I'm raising this issue in the wrong place.  I appreciate your consideration of these changes, small as they may be.