### PR TITLE
correct mistranslation of "not sign" for Italian

### DIFF
--- a/loc/it/symbols/0000.txt
+++ b/loc/it/symbols/0000.txt
@@ -170,7 +170,7 @@
 00A9: Segno di copyright: copia , (C)
 00AA: Indicatore ordinale femminile
 00AB: Virgolette a doppio angolo a sinistra: lasciato Guillemet , chevron
-00AC: Non firmare: trattino angolato (in tipografia)
+00AC: Segno di negazione: trattino angolato (in tipografia)
 00AD: Soft Hyphen: trattino discrezionale
 00AE: Segno registrato: segno di marchio registrato
 00AF: Macron: overline, overbar apl


### PR DESCRIPTION
I just stumbled upon this when I was looking for the "not" symbol (¬). I was really confused at first, took me a minute, but then I understood and found it pretty funny ( ˃ᗜ˂   ) (it came out as meaning "don't sign").

Anyway, here's the correction, I'm wondering if there could be other silly mistakes hiding around, since this looks like a typical machine translation thing, but I haven't dug deep in the code base so I apologize if the extent of my contribution is this small